### PR TITLE
Chapter2: fix tf_keras.ipynb batchs exceeds dataset size

### DIFF
--- a/Chapter2/tf_keras.ipynb
+++ b/Chapter2/tf_keras.ipynb
@@ -157,7 +157,7 @@
     "# 模型评估，测试集为NumPy数据\n",
     "model.evaluate(data, labels, batch_size=50)\n",
     "# 模型评估，测试集为Dataset数据\n",
-    "model.evaluate(dataset, steps=30)"
+    "model.evaluate(dataset, steps=20)"
    ]
   },
   {


### PR DESCRIPTION
There are only 1000 samples, it will error when runs out of dataset size
since it doesn't reuse samples.

Signed-off-by: Chengwei Yang <yangchengwei@qiyi.com>